### PR TITLE
Fix SSL certificate issue

### DIFF
--- a/src/HeLayer.php
+++ b/src/HeLayer.php
@@ -130,6 +130,12 @@ class HeLayer
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
 
+        if ($this->debug) {
+            // this it is necessary because local machines may not have SSL certificates
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        }
+
         $result = curl_exec($ch);
 
         if ($this->debug) {


### PR DESCRIPTION
This commit fixes an issue related with ssl certificate.

If the host machine did not have an SSL certificate, the CURL would not be able to not connect to the destiny.
Now, at least with debug turn on, the SSL certification host validation will be ignored and the CURL will be able to connect with the URL destination.